### PR TITLE
Release 4.0.0 - Update dependencies for Kafka 4.0

### DIFF
--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -2,33 +2,37 @@ version: '3.7'
 
 services:
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.9.0
-    container_name: zookeeper
-    networks: 
-      - kafka-local
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-  
-  
   broker:
-    image: confluentinc/cp-kafka:7.9.0
+    image: confluentinc/cp-kafka:8.0.0
     container_name: broker
     networks: 
       - kafka-local
-    depends_on:
-      - zookeeper
     ports:
       - "9092:9092"
     environment:
-      KAFKA_BROKER_ID: 1
+      # Enable KRaft (replaces Zookeeper)
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_NODE_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@broker:29093"
+      CLUSTER_ID: z5Q_VF3DThqCfPz_Hvk8RA # Generate using docker docker run -it --rm confluentinc/cp-kafka kafka-storage random-uuid
+
+      # Listeners
+      KAFKA_LISTENERS: INTERNAL://broker:29092,TOKEN://broker:9092,CONTROLLER://broker:29093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://broker:29092,TOKEN://broker:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,TOKEN:SASL_SSL,CONTROLLER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+
+      # Metadata Topics
       KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 1
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,TOKEN:SASL_SSL
-      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://broker:29092,TOKEN://broker:9092
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+
+      # Logs
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+
+      # Schema Registry
       KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
 
       # Configure custom Truststore when using SASL_SSL between broker and client
@@ -69,7 +73,7 @@ services:
 
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.9.0
+    image: confluentinc/cp-schema-registry:8.0.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.4.0
+    image: confluentinc/cp-zookeeper:7.9.0
     container_name: zookeeper
     networks: 
       - kafka-local
@@ -13,7 +13,7 @@ services:
   
   
   broker:
-    image: confluentinc/cp-kafka:7.4.0
+    image: confluentinc/cp-kafka:7.9.0
     container_name: broker
     networks: 
       - kafka-local
@@ -69,7 +69,7 @@ services:
 
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.4.0
+    image: confluentinc/cp-schema-registry:7.9.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -68,6 +68,8 @@ services:
       KAFKA_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: https://login.microsoftonline.com/f3292839-9228-4d56-a08c-6023c5d71e65/discovery/v2.0/keys # to edit
       KAFKA_SASL_OAUTHBEARER_SCOPE_CLAIM: scp
       KAFKA_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "c8843062-a9dc-49ed-8874-3b2d911ca41a"
+      # Add system property to allow keys url to be allowed
+      KAFKA_OPTS: "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=https://login.microsoftonline.com/f3292839-9228-4d56-a08c-6023c5d71e65/discovery/v2.0/keys"
     volumes:
       - "{E2E_DIR_PATH}/broker:/var/ssl/private"
 

--- a/e2e/test-consumer/pom.xml
+++ b/e2e/test-consumer/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>io.github.nniikkoollaaii</groupId>
             <artifactId>kafka-sasl-oauthbearer-workload-identity</artifactId>
-            <version>1.1.3</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
           <groupId>io.confluent</groupId>

--- a/e2e/test-consumer/pom.xml
+++ b/e2e/test-consumer/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>io.github.nniikkoollaaii.Main</mainClass>
-        <avro.version>1.11.1</avro.version>
-        <io.confluent.schema-registry.version>7.4.0</io.confluent.schema-registry.version>
+        <avro.version>1.11.4</avro.version>
+        <io.confluent.schema-registry.version>7.9.0</io.confluent.schema-registry.version>
     </properties>
 
     <dependencies>
@@ -23,14 +23,14 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.4.1</version>
+            <version>3.9.0</version>
         </dependency>
 
 
         <dependency>
             <groupId>io.github.nniikkoollaaii</groupId>
             <artifactId>kafka-sasl-oauthbearer-workload-identity</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.3</version>
         </dependency>
         <dependency>
           <groupId>io.confluent</groupId>

--- a/e2e/test-consumer/pom.xml
+++ b/e2e/test-consumer/pom.xml
@@ -23,14 +23,14 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.9.0</version>
+            <version>4.0.0</version>
         </dependency>
 
 
         <dependency>
             <groupId>io.github.nniikkoollaaii</groupId>
             <artifactId>kafka-sasl-oauthbearer-workload-identity</artifactId>
-            <version>3.9.0</version>
+            <version>4.0.0</version>
         </dependency>
         <dependency>
           <groupId>io.confluent</groupId>

--- a/e2e/test-producer/pom.xml
+++ b/e2e/test-producer/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>io.github.nniikkoollaaii.Main</mainClass>
         <avro.version>1.11.4</avro.version>
-        <io.confluent.schema-registry.version>7.9.0</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>8.0.0</io.confluent.schema-registry.version>
     </properties>
 
     <dependencies>
@@ -24,14 +24,14 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.9.0</version>
+            <version>4.0.0</version>
         </dependency>
 
 
         <dependency>
             <groupId>io.github.nniikkoollaaii</groupId>
             <artifactId>kafka-sasl-oauthbearer-workload-identity</artifactId>
-            <version>3.9.0</version>
+            <version>4.0.0</version>
         </dependency>
         <dependency>
           <groupId>io.confluent</groupId>

--- a/e2e/test-producer/pom.xml
+++ b/e2e/test-producer/pom.xml
@@ -15,8 +15,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>io.github.nniikkoollaaii.Main</mainClass>
-        <avro.version>1.11.1</avro.version>
-        <io.confluent.schema-registry.version>7.4.0</io.confluent.schema-registry.version>
+        <avro.version>1.11.4</avro.version>
+        <io.confluent.schema-registry.version>7.9.0</io.confluent.schema-registry.version>
     </properties>
 
     <dependencies>
@@ -24,14 +24,14 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.4.1</version>
+            <version>3.9.0</version>
         </dependency>
 
 
         <dependency>
             <groupId>io.github.nniikkoollaaii</groupId>
             <artifactId>kafka-sasl-oauthbearer-workload-identity</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.3</version>
         </dependency>
         <dependency>
           <groupId>io.confluent</groupId>

--- a/e2e/test-producer/pom.xml
+++ b/e2e/test-producer/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>io.github.nniikkoollaaii</groupId>
             <artifactId>kafka-sasl-oauthbearer-workload-identity</artifactId>
-            <version>1.1.3</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
           <groupId>io.confluent</groupId>

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -4,7 +4,7 @@ echo ""
 echo "Create Kafka cluster"
 echo ""
 sed -i "s|{E2E_DIR_PATH}|$(pwd)|g" ./docker-compose.yaml
-docker-compose -f docker-compose.yaml up -d 
+docker compose -f docker-compose.yaml up -d
 
 echo ""
 echo "Sleep 10s"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.nniikkoollaaii</groupId>
     <artifactId>kafka-sasl-oauthbearer-workload-identity</artifactId>
-    <version>3.9.0</version>
+    <version>4.0.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Kafka Client Login Callback Handler to be used in Kafka Clients authenticating to an OAuth2 enabled Kafka Broker AND running on an Azure Service with Workload Identity enabled.</description>
@@ -12,8 +12,8 @@
 
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencyManagement>
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.31</version>
+                <version>1.2.38</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.9.0</version>
+            <version>4.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.azure/azure-identity -->
         <!-- https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview#azure-identity-client-libraries -->
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>
-            <version>7.9.0</version> <!-- 7.5.0 -->
+            <version>8.0.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.nniikkoollaaii</groupId>
     <artifactId>kafka-sasl-oauthbearer-workload-identity</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Kafka Client Login Callback Handler to be used in Kafka Clients authenticating to an OAuth2 enabled Kafka Broker AND running on an Azure Service with Workload Identity enabled.</description>
@@ -16,25 +16,36 @@
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-sdk-bom</artifactId>
+                <version>1.2.31</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.4.0</version>
+            <version>3.9.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.azure/azure-identity -->
         <!-- https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview#azure-identity-client-libraries -->
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.9.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>0.9.3</version>
+            <version>0.9.6</version>
         </dependency>
 
 
@@ -42,7 +53,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>
-            <version>7.4.0</version> <!-- 7.5.0 -->
+            <version>7.9.0</version> <!-- 7.5.0 -->
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencyManagement>
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -84,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.github.nniikkoollaaii</groupId>
     <artifactId>kafka-sasl-oauthbearer-workload-identity</artifactId>
-    <version>1.1.3</version>
+    <version>3.9.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Kafka Client Login Callback Handler to be used in Kafka Clients authenticating to an OAuth2 enabled Kafka Broker AND running on an Azure Service with Workload Identity enabled.</description>


### PR DESCRIPTION
Updated Kafka Dependencies:

- org.apache.kafka.kafka-clients to 4.0.0
- io.confluent.kafka-schema-regsitry-client to 8.0.0

Replaces Zookeeper within e2e-Tests with KRaft Implementation
